### PR TITLE
Transformation between freespace_trees and bitmaps

### DIFF
--- a/fs/ext4/ext4.h
+++ b/fs/ext4/ext4.h
@@ -59,7 +59,7 @@
  * with DOUBLE_CHECK defined mballoc creates persistent in-core
  * bitmaps, maintains and uses them to check for double allocations
  */
-#define DOUBLE_CHECK__
+#define DOUBLE_CHECK
 
 /*
  * Define EXT4FS_DEBUG to produce debug messages
@@ -1390,6 +1390,15 @@ struct ext4_super_block {
 	(sbi->s_encoding_flags & EXT4_ENC_STRICT_MODE_FL)
 
 /*
+ * Struct containing rb_node 
+ * for tracking free spaces using Red Black tree
+ */
+struct ext4_freespace_root {
+	struct rb_root frsp_t_root;
+	spinlock_t frsp_t_lock; 
+};
+
+/*
  * fourth extended-fs super-block data in memory
  */
 struct ext4_sb_info {
@@ -1523,6 +1532,9 @@ struct ext4_sb_info {
 	unsigned int s_log_groups_per_flex;
 	struct flex_groups * __rcu *s_flex_groups;
 	ext4_group_t s_flex_groups_allocated;
+
+	/* rb_tree roots for flex_groups */
+	struct ext4_freespace_root *s_mb_freespace_trees;
 
 	/* workqueue for reserved extent conversions (buffered io) */
 	struct workqueue_struct *rsv_conversion_wq;

--- a/fs/ext4/ext4.h
+++ b/fs/ext4/ext4.h
@@ -1395,7 +1395,7 @@ struct ext4_super_block {
  */
 struct ext4_freespace_root {
 	struct rb_root frsp_t_root;
-	spinlock_t frsp_t_lock; 
+	struct mutex frsp_t_lock; 
 };
 
 /*
@@ -2645,6 +2645,8 @@ extern long ext4_mb_max_to_scan;
 extern int ext4_mb_init(struct super_block *);
 extern int ext4_mb_release(struct super_block *);
 extern ext4_fsblk_t ext4_mb_new_blocks(handle_t *,
+				struct ext4_allocation_request *, int *);
+extern ext4_fsblk_t ext4_mb_freespace_tree_new_blocks(handle_t *,
 				struct ext4_allocation_request *, int *);
 extern int ext4_mb_reserve_blocks(struct super_block *, int);
 extern void ext4_discard_preallocations(struct inode *);

--- a/fs/ext4/mballoc.h
+++ b/fs/ext4/mballoc.h
@@ -82,9 +82,9 @@ do {									\
  * Struct for tree node in freespace_tree
  */
 struct ext4_freespace_node {
-	unsigned int offset; /* Start block offset w.r.t. current flexible group*/
-	unsigned int length; /* Length of free spaces in number of clusters*/
-	struct rb_node node; 
+	unsigned int frsp_offset; /* Start block offset w.r.t. current flexible group*/
+	unsigned int frsp_length; /* Length of free spaces in number of clusters*/
+	struct rb_node frsp_node; 
 };
 
 
@@ -155,6 +155,12 @@ struct ext4_locality_group {
 	spinlock_t		lg_prealloc_lock;
 };
 
+struct ext4_tree_extent {
+	unsigned int te_idx;	 /* flex_bg index (tree index) */
+	unsigned int te_offset;  /* block offset w.r.t tree */
+	unsigned int te_len;	 /* length */
+};
+
 struct ext4_allocation_context {
 	struct inode *ac_inode;
 	struct super_block *ac_sb;
@@ -170,6 +176,9 @@ struct ext4_allocation_context {
 
 	/* copy of the best found extent taken before preallocation efforts */
 	struct ext4_free_extent ac_f_ex;
+
+	/* the best found tree node */
+	struct ext4_tree_extent ac_b_tree_ex;
 
 	__u16 ac_groups_scanned;
 	__u16 ac_found;

--- a/fs/ext4/mballoc.h
+++ b/fs/ext4/mballoc.h
@@ -78,6 +78,16 @@ do {									\
 #define MB_DEFAULT_GROUP_PREALLOC	512
 
 
+/*
+ * Struct for tree node in freespace_tree
+ */
+struct ext4_freespace_node {
+	unsigned int offset; /* Start block offset w.r.t. current flexible group*/
+	unsigned int length; /* Length of free spaces in number of clusters*/
+	struct rb_node node; 
+};
+
+
 struct ext4_free_data {
 	/* this links the free block information from sb_info */
 	struct list_head		efd_list;


### PR DESCRIPTION
add freespace tree root struct with spinlocks 

add entries to freespace trees in ext4_sb_info

add init function for freespace trees

add freespace tree node struct

add freespace tree load/insert/can_merge functions

change units of freespcae_node_length from blks to clusters

fixed syntax bug and flex_index bug

delete debugging output messages

add tree_to_bitmap conversion functions

fix null pointer bug and offset bug in fuzzy search